### PR TITLE
許可するドメインをアプリケーションから設定できるように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ config.middleware.use Rack::GSuiteRestriction, path,
   :client_id     => GOOGLE_OAUTH_CLIENT_ID,          # required
   :client_secret => GOOGLE_OAUTH_CLIENT_SECRET,      # required
   :omniauth_path_prefix => /path/to/authentication,  # optional ( default '/admin/auth' )
+  :oauth_permit_domains => ['example.com'],          # optional ( default ['colorfulcompany.co.jp'] )
 ```
 
 ### Rack app
@@ -39,6 +40,7 @@ Rack::Builder.new do
     :client_id     => GOOGLE_OAUTH_CLIENT_ID,          # required
     :client_secret => GOOGLE_OAUTH_CLIENT_SECRET,      # required
     :omniauth_path_prefix => /path/to/authentication,  # optional ( default '/admin/auth' )
+    :oauth_permit_domains => ['example.com'],          # optional ( default ['colorfulcompany.co.jp'] )
   run Rack::Application
 end
 ```

--- a/lib/rack/gsuite_restriction.rb
+++ b/lib/rack/gsuite_restriction.rb
@@ -13,6 +13,7 @@ module Rack
     #
     def initialize(app, path, config = {})
       dumb_app = lambda {|env| [418, {}, ['not captured']]}
+      @config = config
       @oauth_client = OAuthClient.new(app, config)
       match_path = build_match_path(path, @oauth_client)
 
@@ -40,7 +41,7 @@ module Rack
     def need_auth!(req, res, match = nil)
       res.status = 401
 
-      status, header, body = (RequestController.new(oauth_client)).build(req, res)
+      status, header, body = (RequestController.new(oauth_client, @config)).build(req, res)
       res.status = status
       header.keys.each { |k| res[k] = header[k] }
 

--- a/lib/rack/gsuite_restriction/request_controller.rb
+++ b/lib/rack/gsuite_restriction/request_controller.rb
@@ -5,12 +5,14 @@ require_relative './session/location'
 module Rack
   class GSuiteRestriction
     class RequestController
+      PERMIT_DOMAINS = ['colorfulcompany.co.jp'].freeze
 
       #
       # @param [OAuthClient] oauth_client
       #
-      def initialize(oauth_client)
+      def initialize(oauth_client, config)
         @oauth_client = oauth_client
+        @domains = config[:oauth_permit_domains] || PERMIT_DOMAINS
       end
       attr_reader :oauth_client
 
@@ -22,7 +24,7 @@ module Rack
       def build(request, response)
         res = response.finish
 
-        user_session = create_user_session(request)
+        user_session = create_user_session(request, @domains)
         location = Session::Location.new(request)
   
         case request.path
@@ -80,8 +82,8 @@ module Rack
       # @param [Rack::Request] req
       # @return [Session::User]
       # 
-      def create_user_session(req)
-        Session::User.new(req)
+      def create_user_session(req, domeins)
+        Session::User.new(req, domeins)
       end
     end
   end

--- a/lib/rack/gsuite_restriction/session/user.rb
+++ b/lib/rack/gsuite_restriction/session/user.rb
@@ -5,17 +5,16 @@ module Rack
     class Session
       class User < Base
         KEY = "#{KEY_BASE}.user".freeze
-        DOMAIN = 'colorfulcompany.co.jp'.freeze
 
         # 
         # @param [Rack::Request] request
-        # @param [String] domain
+        # @param [Array] domains
         # 
-        def initialize(request, domain = DOMAIN)
+        def initialize(request, domains)
           super(request)
-          @domain = domain
+          @domains = domains
         end
-        attr_reader :domain
+        attr_reader :domains
 
         # 
         # @param [Object] user
@@ -39,7 +38,7 @@ module Rack
         # @return [Boolean]
         # 
         def valid?(user)
-          domain == user.info.email.split('@')[1]
+          domains.include?(user.info.email.split('@')[1])
         end
       end
     end

--- a/lib/rack/gsuite_restriction/version.rb
+++ b/lib/rack/gsuite_restriction/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class GSuiteRestriction
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
## Issue
#6 

## 目的
`colorfulcompany.co.jp` 以外のドメインの認証が行えない
外からドメインを設定できるようにオプションを追加する

## 変更点
 1. `option[:oauth_permit_domains]` を追加
 2. `UserSession#valid?`　で与えられたドメインを用いてチェックをするように変更

## 備考
version を 0.2.0 に更新しました
merge 後にタグを打ちます
